### PR TITLE
「出席状況の確認」のCSSの改善

### DIFF
--- a/src/views/dashboard-css.html
+++ b/src/views/dashboard-css.html
@@ -1,5 +1,111 @@
+*, ::before, ::after {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x: ;
+  --tw-pan-y: ;
+  --tw-pinch-zoom: ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position: ;
+  --tw-gradient-via-position: ;
+  --tw-gradient-to-position: ;
+  --tw-ordinal: ;
+  --tw-slashed-zero: ;
+  --tw-numeric-figure: ;
+  --tw-numeric-spacing: ;
+  --tw-numeric-fraction: ;
+  --tw-ring-inset: ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur: ;
+  --tw-brightness: ;
+  --tw-contrast: ;
+  --tw-grayscale: ;
+  --tw-hue-rotate: ;
+  --tw-invert: ;
+  --tw-saturate: ;
+  --tw-sepia: ;
+  --tw-drop-shadow: ;
+  --tw-backdrop-blur: ;
+  --tw-backdrop-brightness: ;
+  --tw-backdrop-contrast: ;
+  --tw-backdrop-grayscale: ;
+  --tw-backdrop-hue-rotate: ;
+  --tw-backdrop-invert: ;
+  --tw-backdrop-opacity: ;
+  --tw-backdrop-saturate: ;
+  --tw-backdrop-sepia: ;
+  --tw-contain-size: ;
+  --tw-contain-layout: ;
+  --tw-contain-paint: ;
+  --tw-contain-style: ;
+}
+::backdrop {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x: ;
+  --tw-pan-y: ;
+  --tw-pinch-zoom: ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position: ;
+  --tw-gradient-via-position: ;
+  --tw-gradient-to-position: ;
+  --tw-ordinal: ;
+  --tw-slashed-zero: ;
+  --tw-numeric-figure: ;
+  --tw-numeric-spacing: ;
+  --tw-numeric-fraction: ;
+  --tw-ring-inset: ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur: ;
+  --tw-brightness: ;
+  --tw-contrast: ;
+  --tw-grayscale: ;
+  --tw-hue-rotate: ;
+  --tw-invert: ;
+  --tw-saturate: ;
+  --tw-sepia: ;
+  --tw-drop-shadow: ;
+  --tw-backdrop-blur: ;
+  --tw-backdrop-brightness: ;
+  --tw-backdrop-contrast: ;
+  --tw-backdrop-grayscale: ;
+  --tw-backdrop-hue-rotate: ;
+  --tw-backdrop-invert: ;
+  --tw-backdrop-opacity: ;
+  --tw-backdrop-saturate: ;
+  --tw-backdrop-sepia: ;
+  --tw-contain-size: ;
+  --tw-contain-layout: ;
+  --tw-contain-paint: ;
+  --tw-contain-style: ;
+}
 /*
-! tailwindcss v3.4.10 | MIT License | https://tailwindcss.com
+! tailwindcss v3.4.13 | MIT License | https://tailwindcss.com
 */
 /*
 1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
@@ -366,147 +472,36 @@ video {
 [hidden] {
   display: none;
 }
-*, ::before, ::after {
-  --tw-border-spacing-x: 0;
-  --tw-border-spacing-y: 0;
-  --tw-translate-x: 0;
-  --tw-translate-y: 0;
-  --tw-rotate: 0;
-  --tw-skew-x: 0;
-  --tw-skew-y: 0;
-  --tw-scale-x: 1;
-  --tw-scale-y: 1;
-  --tw-pan-x: ;
-  --tw-pan-y: ;
-  --tw-pinch-zoom: ;
-  --tw-scroll-snap-strictness: proximity;
-  --tw-gradient-from-position: ;
-  --tw-gradient-via-position: ;
-  --tw-gradient-to-position: ;
-  --tw-ordinal: ;
-  --tw-slashed-zero: ;
-  --tw-numeric-figure: ;
-  --tw-numeric-spacing: ;
-  --tw-numeric-fraction: ;
-  --tw-ring-inset: ;
-  --tw-ring-offset-width: 0px;
-  --tw-ring-offset-color: #fff;
-  --tw-ring-color: rgb(59 130 246 / 0.5);
-  --tw-ring-offset-shadow: 0 0 #0000;
-  --tw-ring-shadow: 0 0 #0000;
-  --tw-shadow: 0 0 #0000;
-  --tw-shadow-colored: 0 0 #0000;
-  --tw-blur: ;
-  --tw-brightness: ;
-  --tw-contrast: ;
-  --tw-grayscale: ;
-  --tw-hue-rotate: ;
-  --tw-invert: ;
-  --tw-saturate: ;
-  --tw-sepia: ;
-  --tw-drop-shadow: ;
-  --tw-backdrop-blur: ;
-  --tw-backdrop-brightness: ;
-  --tw-backdrop-contrast: ;
-  --tw-backdrop-grayscale: ;
-  --tw-backdrop-hue-rotate: ;
-  --tw-backdrop-invert: ;
-  --tw-backdrop-opacity: ;
-  --tw-backdrop-saturate: ;
-  --tw-backdrop-sepia: ;
-  --tw-contain-size: ;
-  --tw-contain-layout: ;
-  --tw-contain-paint: ;
-  --tw-contain-style: ;
-}
-::backdrop {
-  --tw-border-spacing-x: 0;
-  --tw-border-spacing-y: 0;
-  --tw-translate-x: 0;
-  --tw-translate-y: 0;
-  --tw-rotate: 0;
-  --tw-skew-x: 0;
-  --tw-skew-y: 0;
-  --tw-scale-x: 1;
-  --tw-scale-y: 1;
-  --tw-pan-x: ;
-  --tw-pan-y: ;
-  --tw-pinch-zoom: ;
-  --tw-scroll-snap-strictness: proximity;
-  --tw-gradient-from-position: ;
-  --tw-gradient-via-position: ;
-  --tw-gradient-to-position: ;
-  --tw-ordinal: ;
-  --tw-slashed-zero: ;
-  --tw-numeric-figure: ;
-  --tw-numeric-spacing: ;
-  --tw-numeric-fraction: ;
-  --tw-ring-inset: ;
-  --tw-ring-offset-width: 0px;
-  --tw-ring-offset-color: #fff;
-  --tw-ring-color: rgb(59 130 246 / 0.5);
-  --tw-ring-offset-shadow: 0 0 #0000;
-  --tw-ring-shadow: 0 0 #0000;
-  --tw-shadow: 0 0 #0000;
-  --tw-shadow-colored: 0 0 #0000;
-  --tw-blur: ;
-  --tw-brightness: ;
-  --tw-contrast: ;
-  --tw-grayscale: ;
-  --tw-hue-rotate: ;
-  --tw-invert: ;
-  --tw-saturate: ;
-  --tw-sepia: ;
-  --tw-drop-shadow: ;
-  --tw-backdrop-blur: ;
-  --tw-backdrop-brightness: ;
-  --tw-backdrop-contrast: ;
-  --tw-backdrop-grayscale: ;
-  --tw-backdrop-hue-rotate: ;
-  --tw-backdrop-invert: ;
-  --tw-backdrop-opacity: ;
-  --tw-backdrop-saturate: ;
-  --tw-backdrop-sepia: ;
-  --tw-contain-size: ;
-  --tw-contain-layout: ;
-  --tw-contain-paint: ;
-  --tw-contain-style: ;
-}
-.absolute {
-  position: absolute;
-}
-.left-0 {
-  left: 0px;
-}
-.top-0 {
-  top: 0px;
-}
-.m-20 {
-  margin: 5rem;
-}
 .mx-auto {
   margin-left: auto;
   margin-right: auto;
 }
-.flex {
-  display: flex;
+.grid {
+  display: grid;
 }
-.h-screen {
-  height: 100vh;
+.h-fit {
+  height: fit-content;
 }
-.w-screen {
-  width: 100vw;
+.min-h-screen {
+  min-height: 100vh;
+}
+.w-10\/12 {
+  width: 83.333333%;
+}
+.w-2\/3 {
+  width: 66.666667%;
+}
+.w-\[100dvw\] {
+  width: 100dvw;
 }
 .flex-1 {
   flex: 1 1 0%;
 }
-.justify-center {
-  justify-content: center;
+.grid-cols-auto-fit {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
-.space-x-5 > :not([hidden]) ~ :not([hidden]) {
-  --tw-space-x-reverse: 0;
-  margin-right: calc(1.25rem * var(--tw-space-x-reverse));
-  margin-left: calc(1.25rem * calc(1 - var(--tw-space-x-reverse)));
+.gap-5 {
+  gap: 1.25rem;
 }
 .rounded-md {
   border-radius: 0.375rem;
@@ -529,9 +524,6 @@ video {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
 }
-.p-0\.5 {
-  padding: 0.125rem;
-}
 .p-10 {
   padding: 2.5rem;
 }
@@ -540,6 +532,13 @@ video {
 }
 .p-4 {
   padding: 1rem;
+}
+.p-5 {
+  padding: 1.25rem;
+}
+.py-10 {
+  padding-top: 2.5rem;
+  padding-bottom: 2.5rem;
 }
 .text-center {
   text-align: center;
@@ -575,4 +574,9 @@ video {
   --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+@media (min-width: 768px) {
+  .md\:w-2\/3 {
+    width: 66.666667%;
+  }
 }

--- a/src/views/dashboard.html
+++ b/src/views/dashboard.html
@@ -1,16 +1,18 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
   <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width">
     <base target="_top">
     <style>
       <?!=cssContent?>
     </style>
   <head>
   <body>
-    <div class="absolute left-0 top-0 h-screen w-screen bg-orange-50 p-0.5">
-      <div class="bg-white shadow-2xl p-10 m-20">
+    <div class="w-[100dvw] h-fit min-h-screen bg-orange-50 py-10">
+      <div class="mx-auto w-10/12 md:w-2/3 bg-white shadow-2xl p-5">
         <div class="border-b-4">
-          <h1 class="text-3xl font-sans font-bold text-orange-500 p-10">
+          <h1 class="text-3xl text-center font-sans font-bold text-orange-500 p-10">
             出席状況確認
           </h1>
         </div>
@@ -18,18 +20,18 @@
           <p class="text-xl border-b-2 p-4">
             通常練習の出席率
           </p>
-          <div class="justify-center p-4 space-x-5 flex">
+          <div class="grid grid-cols-auto-fit gap-5 p-4 text-center text-lg">
             <div class="flex-1 shadow-md rounded-md bg-gray-100">
-              <p class="text-center text-lg border-b-2 p-3">前曲</p>
-              <p class="text-center text-lg p-3"><?=attendanceNormalOverture?></p>
+              <p class="border-b-2 p-3">前曲</p>
+              <p class="p-3"><?=attendanceNormalOverture?></p>
             </div>
             <div class="flex-1 shadow-md rounded-md bg-gray-100">
-              <p class="text-center text-lg border-b-2 p-3">中曲</p>
-              <p class="text-center text-lg p-3"><?=attendanceNormalMiddle?></p>
+              <p class="border-b-2 p-3">中曲</p>
+              <p class="p-3"><?=attendanceNormalMiddle?></p>
             </div>
             <div class="flex-1 shadow-md rounded-md bg-gray-100">
-              <p class="text-center text-lg border-b-2 p-3">メイン曲</p>
-              <p class="text-center text-lg p-3"><?=attendanceNormalMain?></p>
+              <p class="border-b-2 p-3">メイン曲</p>
+              <p class="p-3"><?=attendanceNormalMain?></p>
             </div>
           </div>
         </div>
@@ -37,18 +39,18 @@
           <p class="text-xl border-b-2 p-4">
             Tutti練習の出席率
           </p>
-          <div class="justify-center p-4 space-x-5 flex">
+          <div class="grid grid-cols-auto-fit gap-5 p-4 text-center text-lg">
             <div class="flex-1 shadow-md rounded-md bg-gray-100">
-              <p class="text-center text-lg border-b-2 p-3">前曲</p>
-              <p class="text-center text-lg p-3"><?=attendanceTuttiOverture?></p>
+              <p class="border-b-2 p-3">前曲</p>
+              <p class="p-3"><?=attendanceTuttiOverture?></p>
             </div>
             <div class="flex-1 shadow-md rounded-md bg-gray-100">
-              <p class="text-center text-lg border-b-2 p-3">中曲</p>
-              <p class="text-center text-lg p-3"><?=attendanceTuttiMiddle?></p>
+              <p class="border-b-2 p-3">中曲</p>
+              <p class="p-3"><?=attendanceTuttiMiddle?></p>
             </div>
             <div class="flex-1 shadow-md rounded-md bg-gray-100">
-              <p class="text-center text-lg border-b-2 p-3">メイン曲</p>
-              <p class="text-center text-lg p-3"><?=attendanceTuttiMain?></p>
+              <p class="border-b-2 p-3">メイン曲</p>
+              <p class="p-3"><?=attendanceTuttiMain?></p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
出席状況の確認をモバイル版で開くと表示が崩れまくる。

![image](https://github.com/user-attachments/assets/e57f6037-5d8e-4626-9f35-8d99bdae7c93)

調べたらTailwindの指定が相当甘かったので手元で直してみました。

### 変更点

- Media Queryで余白部分の大きさをコントロールしました。
- `display: flex`を`display: grid`に変更し、`grid-template-columns`でボックスを敷き詰められるように変更。これにより、最小の大きさを決めつつレスポンシブに大きさが変わるようになります。
- `width`は`fit-content`を指定しつつ、`min-width`で画面いっぱいまで広げるようにしました。

こんな感じになるはずです

![image](https://github.com/user-attachments/assets/24f54ab4-23f0-4553-a6ff-886482e693f9)

